### PR TITLE
Add CSS for whitelist and details XULs to Corrent Linux Rendering

### DIFF
--- a/chrome/content/details.xul
+++ b/chrome/content/details.xul
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <dialog title="Details" orient="vertical" autostretch="always" onload="updateDetails();" buttons="accept" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
   <script type="application/javascript" src="chrome://dnsbl/content/details.js"/>
   <groupbox id='containerBox' align="center" orient="horizontal">

--- a/chrome/content/whitelist.xul
+++ b/chrome/content/whitelist.xul
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
 <dialog title="Whitelist" orient="vertical" autostretch="always" onload="viewWhitelist();" buttons="accept" xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
   <script type="application/javascript" src="chrome://dnsbl/content/whitelist.js"/>
   <script src="chrome://dnsbl/content/jquery-1.11.2.min.js" />

--- a/chrome/skin/details.css
+++ b/chrome/skin/details.css
@@ -1,0 +1,6 @@
+window {
+   -moz-box-align: start;
+   background-color: -moz-dialog;
+   font: -moz-dialog;
+   padding: 2em;
+}

--- a/chrome/skin/whitelist.css
+++ b/chrome/skin/whitelist.css
@@ -1,0 +1,6 @@
+window {
+   -moz-box-align: start;
+   background-color: -moz-dialog;
+   font: -moz-dialog;
+   padding: 2em;
+}


### PR DESCRIPTION
Add CSS for whitelist.xul and details.xul to correct rendering problems
that appeared in Thunderbird 31.4.0 for Linux.
