### PR TITLE
Make RBL requests using fully qualified names

### DIFF
--- a/chrome/content/dnsbl.js
+++ b/chrome/content/dnsbl.js
@@ -356,7 +356,7 @@ function doRBLcheck(relays, rblService, returnPath, mailID) {
         match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec (addr);
         if (match) {
            reverseAddr = match[4] + "." + match[3] + "." + match[2] + "." + match[1];
-           rblQuery = reverseAddr + "." + rblService;
+           rblQuery = reverseAddr + "." + rblService + ".";
 
            numDNSLookups++;
 


### PR DESCRIPTION
Make sure the A records requested from the RBL services include the
trailing ".". This makes sure the local workstation operating system does not
automatically "search" for the RBL name with the local domain name
appended.

This fixes issue #3.
